### PR TITLE
Please pull tweak to mousewheel plugin

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -50,6 +50,7 @@ $.fn.extend({
 function handler(event) {
     var orgEvent = event, args = [].slice.call( arguments, 1 ), delta = 0, returnValue = true, deltaX = 0, deltaY = 0;
     
+    var orgEvent = event || window.event, args = [].slice.call( arguments, 1 ), delta = 0, returnValue = true, deltaX = 0, deltaY = 0;
     event = $.event.fix(event || window.event);
     event.type = "mousewheel";
     


### PR DESCRIPTION
Hi Brandon,

A user of my jScrollPane plugin noticed that version 3.0.3 of the mousewheel plugin wasn't working correctly in IE (see brandonaaron/jquery-mousewheel#3). I've implemented what appears to be a simple fix on my fork,

Thanks,

Kelvin :)
