### PR TITLE
Added "eventData" argument support to Mousewheel event handler

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -37,8 +37,12 @@ $.event.special.mousewheel = {
 };
 
 $.fn.extend({
-    mousewheel: function(fn) {
-        return fn ? this.bind("mousewheel", fn) : this.trigger("mousewheel");
+    mousewheel: function(data, fn) {
+        if (fn == null) {
+          fn = data;
+          data = null;
+        }
+        return fn ? this.bind("mousewheel", data, fn) : this.trigger("mousewheel");
     },
     
     unmousewheel: function(fn) {


### PR DESCRIPTION
Hi Brandon,

Thanks for providing the code for your jQuery mousewheel plugin.

I needed to pass additional data to the handler so I used code from jQuery's bind handler to implement the eventData argument.

Now you can do this, as with the other mouse events:

$.mousewheel({someVar: 42, prop: 'value'}, function (event, delta) {
    alert(event.data.someVar);
});

Cheers,
Daniel
