### PR TITLE
event.detail not working in FF7

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -59,8 +59,8 @@ function handler(event) {
     event.type = "mousewheel";
     
     // Old school scrollwheel delta
-    if ( event.wheelDelta ) { delta = event.wheelDelta/120; }
-    if ( event.detail     ) { delta = -event.detail/3; }
+    if ( orgEvent.wheelDelta ) { delta = orgEvent.wheelDelta/120; }
+    if ( orgEvent.detail     ) { delta = -orgEvent.detail/3; }
     
     // New school multidimensional scroll (touchpads) deltas
     deltaY = delta;


### PR DESCRIPTION
Hi,
I've noticed some problems with your lib using the latest firefox version. The value of the deltaY argument is always zero because it isn't looking for the detail value in the DOMMouseScroll event.
