### PR TITLE
Corrected `mousewheel` function

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -43,8 +43,14 @@ $.event.special.mousewheel = {
 };
 
 $.fn.extend({
-    mousewheel: function(fn) {
-        return fn ? this.bind("mousewheel", fn) : this.trigger("mousewheel");
+    mousewheel: function(data, fn) {
+        if ( fn == null ) {
+            fn = data;
+            data = null;
+        }
+        return arguments.length > 0 ?
+            this.bind( 'mousewheel', data, fn ) :
+            this.trigger( 'mousewheel' );
     },
     
     unmousewheel: function(fn) {


### PR DESCRIPTION
I've corrected the `mousewheel` function to pass the `data` parameter in the same manner as other convenience binding methods.

See: http://code.jquery.com/jquery-1.7.2.js, Lines: 3914-3923
