### PR TITLE
Updated README to point to Github pages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,8 @@ Here is an example of using both the bind and helper method syntax.
         console.log(delta, deltaX, deltaY);
     });
 
+## See it in action
+[See the tests on Github](http://brandonaaron.github.com/jquery-mousewheel/test) or navigate to `test/index.html` in your browser.
 
 ## License
 


### PR DESCRIPTION
I think it'd be swell if the `test/index.html` page were hosted on github pages so I could run it without cloning the repository. I updated the README to point to the repository hosted on github pages, in case you wanted to push to gh-pages. :) 
