### PR TITLE
FF17 Fix

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -12,7 +12,7 @@
 
 (function($) {
 
-var types = ['DOMMouseScroll', 'mousewheel'];
+var types = ['DOMMouseScroll', 'mousewheel', 'MozMousePixelScroll', 'wheel'];
 
 if ($.event.fixHooks) {
     for ( var i=types.length; i; ) {


### PR DESCRIPTION
added new listener for FF17+ (works even with FF Aurora 19a2), fixes preventDefault on scroll

wheel does not work anymore / or at the moment.

try this instead:

var types = ['DOMMouseScroll', 'mousewheel', 'MozMousePixelScroll', 'wheel'];

MDN:
The DOM MozMousePixelScroll event is fired asynchronously when mouse wheel or similar device is operated. It's represented by the MouseScrollEvent interface.

If you want to prevent the default action of mouse wheel events on Gecko 17 (Firefox 17) or later, you need to call preventDefault() of wheel because if two or more wheel events caused only 1 pixel scroll, this event wouldn't be fired.

Hint:
So adding MozMousePixelScroll will fix this problem. But the speed is really high.. maybe some adjustments are required. I've also tried to use this whitout "wheel" and this works too. But i think upcoming releases will just use the wheel event.

Tested with FF17 and FF Aurora (19a2), Safari 6, current Chrome.. Works!
