### PR TITLE
add MozMousePixelScroll to the fixed events list

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -23,7 +23,7 @@
     }
 }(function ($) {
 
-    var toFix = ['wheel', 'mousewheel', 'DOMMouseScroll'];
+    var toFix = ['wheel', 'mousewheel', 'DOMMouseScroll', 'MozMousePixelScroll'];
     var toBind = 'onwheel' in document || document.documentMode >= 9 ? ['wheel'] : ['mousewheel', 'DomMouseScroll', 'MozMousePixelScroll'];
     var lowestDelta, lowestDeltaXY;
 


### PR DESCRIPTION
Right now jquery.mousewheel binds to the MozMousePixelScroll event but it's not being fixed by mouseHooks like the other events and this leads to inconsistent behaviour.
