### PR TITLE
Added basic ie8 support

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -108,6 +108,14 @@
         deltaX = Math[fn](deltaX / lowestDeltaXY);
         deltaY = Math[fn](deltaY / lowestDeltaXY);
 
+        // <=ie9 (fix for ie8)
+        try { 
+          event.originalEvent.hasOwnProperty('wheelDelta') 
+        }
+        catch(e) {
+          deltaY = deltaX = delta;
+        }
+
         // Add event and delta to the front of the arguments
         args.unshift(event, delta, deltaX, deltaY);
 


### PR DESCRIPTION
Added basic support for deltaY and deltaX values for ie8, bringing it inline with ie9. Tested on Mac with Browsers: Chrome 27, Firefox 21, Safari 6 & a Windows 7 VM running ie8, ie9.
