### PR TITLE
Fix axis specific deltas on Firefox < 17

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -82,6 +82,18 @@
         if ( orgEvent.wheelDelta ) { delta = orgEvent.wheelDelta; }
         if ( orgEvent.detail )     { delta = orgEvent.detail * -1; }
 
+        if ( orgEvent.axis ) {
+            if ( orgEvent.axis === HORIZONTAL_AXIS ) {
+                deltaX = delta;
+                deltaY = 0;
+            }
+
+            if ( orgEvent.axis === VERTICAL_AXIS ) {
+                deltaX = 0;
+                deltaY = delta;
+            }
+        }
+
         // New school wheel delta (wheel event)
         if ( orgEvent.deltaY ) {
             deltaY = orgEvent.deltaY * -1;


### PR DESCRIPTION
- FF versions less than 17 use DOMMouseScroll event, which provides a
  detail (the magnitude) and axis of the scroll. However, it doesn't
  provide individual dy, dx values, and the axis is currently ignored
  by jquery-mousewheel.
