### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Here is an example of using both the bind and helper method syntax:
 
 ```js
 // using bind
-$('#my_elem').bind('mousewheel', function(event, delta, deltaX, deltaY) {
+$('#my_elem').on('mousewheel', function(event, delta, deltaX, deltaY) {
     console.log(delta, deltaX, deltaY);
 });
 


### PR DESCRIPTION
Replace 'bind' with 'on', since it is the "preferred" way to attach event handlers since jQuery 1.7
http://api.jquery.com/bind/
