### PR TITLE
Normalise offsetX and offsetY on the event

### DIFF
--- a/jquery.mousewheel.js
+++ b/jquery.mousewheel.js
@@ -87,7 +87,9 @@
             delta      = 0,
             deltaX     = 0,
             deltaY     = 0,
-            absDelta   = 0;
+            absDelta   = 0,
+            offsetX    = 0,
+            offsetY    = 0;
         event = $.event.fix(orgEvent);
         event.type = 'mousewheel';
 
@@ -160,11 +162,18 @@
         delta  = Math[ delta  >= 1 ? 'floor' : 'ceil' ](delta  / lowestDelta);
         deltaX = Math[ deltaX >= 1 ? 'floor' : 'ceil' ](deltaX / lowestDelta);
         deltaY = Math[ deltaY >= 1 ? 'floor' : 'ceil' ](deltaY / lowestDelta);
+		
+        // Normalise offsetX and offsetY properties
+        var boundingRect = this.getBoundingClientRect();
+        offsetX = event.clientX - boundingRect.left;
+        offsetY = event.clientY - boundingRect.top;
 
         // Add information to the event object
         event.deltaX = deltaX;
         event.deltaY = deltaY;
         event.deltaFactor = lowestDelta;
+        event.offsetX = offsetX;
+        event.offsetY = offsetY;
         // Go ahead and set deltaMode to 0 since we converted to pixels
         // Although this is a little odd since we overwrite the deltaX/Y
         // properties with normalized deltas.


### PR DESCRIPTION
According to the W3C Working Draft, offsetX and offsetY should be
relative to the padding edge of the target element. The only browser
using this convention is IE. Webkit uses the border edge, Opera uses the
content edge, and FireFox does not support the properties.

Normalizing to the border edge is easiest to do.
